### PR TITLE
fix TOTP Validate - decrypt and use the actual secret

### DIFF
--- a/totp.go
+++ b/totp.go
@@ -246,6 +246,14 @@ func (a *App) ValidateTOTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	secret, err := key.DecryptLegacy(t.EncryptedTotpKey)
+	if err != nil {
+		log.Printf("failed to decrypt TOTP key: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
+		return
+	}
+	t.Key = secret
+
 	valid := totp.Validate(requestBody.Code, t.Key)
 	if !valid {
 		jsonResponse(w, "Invalid", http.StatusUnauthorized)

--- a/totp_test.go
+++ b/totp_test.go
@@ -161,7 +161,8 @@ func (ms *MfaSuite) TestAppDeleteTOTP() {
 func (ms *MfaSuite) TestAppValidateTOTP() {
 	key := newTestKey()
 	otherKey := newTestKey()
-	testTOTP := ms.newPasscode(key)
+	testTOTP, err := newTOTP(ms.app.db, key, "issuer", "name")
+	ms.NoError(err)
 
 	ctxWithAPIKey := context.WithValue(context.Background(), UserContextKey, key)
 	ctxWithOtherAPIKey := context.WithValue(context.Background(), UserContextKey, otherKey)


### PR DESCRIPTION
### Fixed
- Fix the TOTP Validate endpoint. It wasn't using the TOTP secret for validation because it wasn't decrypted and stored in the TOTP Key field. This does the decryption after loading from the database and then uses the secret for validation.