### PR TITLE
log errors but don't send the details to the client

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package mfa
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strings"
@@ -16,13 +17,17 @@ const (
 
 // simpleError is a custom error type that can be JSON-encoded for API responses
 type simpleError struct {
-	Error string `json:"error"`
+	Err string `json:"error"`
 }
 
 // newSimpleError creates a new simpleError from the given error
-func newSimpleError(err error) simpleError {
-	return simpleError{Error: err.Error()}
-}
+func newSimpleError(err error) simpleError { return simpleError{Err: err.Error()} }
+
+// Error satisfies the error interface.
+func (s simpleError) Error() string { return s.Err }
+
+// Is returns true if the error strings are equal.
+func (s simpleError) Is(err error) bool { return s.Err == err.Error() }
 
 // jsonResponse encodes a body as JSON and writes it to the response. It sets the response Content-Type header to
 // "application/json".
@@ -31,6 +36,8 @@ func jsonResponse(w http.ResponseWriter, body interface{}, status int) {
 	switch b := body.(type) {
 	case error:
 		data = newSimpleError(b)
+	case string:
+		data = newSimpleError(errors.New(b))
 	default:
 		data = body
 	}

--- a/api.go
+++ b/api.go
@@ -27,7 +27,7 @@ func newSimpleError(err error) simpleError { return simpleError{Err: err.Error()
 func (s simpleError) Error() string { return s.Err }
 
 // Is returns true if the error strings are equal.
-func (s simpleError) Is(err error) bool { return s.Err == err.Error() }
+func (s simpleError) Is(err error) bool { return s.Err == err.Error() || errors.Is(err, simpleError{}) }
 
 // jsonResponse encodes a body as JSON and writes it to the response. It sets the response Content-Type header to
 // "application/json".

--- a/api.go
+++ b/api.go
@@ -56,7 +56,7 @@ func jsonResponse(w http.ResponseWriter, body interface{}, status int) {
 	w.WriteHeader(status)
 	_, err = w.Write(jBody)
 	if err != nil {
-		log.Printf("failed to write response in jsonResponse: %s\n", err)
+		log.Printf("failed to write response in jsonResponse: %s", err)
 	}
 }
 

--- a/apikey.go
+++ b/apikey.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -26,6 +27,12 @@ const (
 	paramNewKeySecret = "newKeySecret"
 	paramOldKeyId     = "oldKeyId"
 	paramOldKeySecret = "oldKeySecret"
+)
+
+const (
+	apiKeyIsRequired = "apiKeyValue is required"
+	apiKeyNotFound   = "API Key not found"
+	emailIsRequired  = "email is required"
 )
 
 // ApiKey holds API key data from DynamoDB
@@ -170,14 +177,12 @@ func (k *ApiKey) DecryptLegacy(ciphertext string) (string, error) {
 
 	iv, err := base64.StdEncoding.DecodeString(parts[0])
 	if err != nil {
-		fmt.Printf("failed to decode iv: %s\n", err)
-		return "", err
+		return "", fmt.Errorf("failed to decode iv: %w", err)
 	}
 
 	decodedCipher, err := base64.StdEncoding.DecodeString(parts[1])
 	if err != nil {
-		fmt.Printf("failed to decode ciphertext: %s\n", err)
-		return "", err
+		return "", fmt.Errorf("failed to decode ciphertext: %w", err)
 	}
 
 	// plaintext will hold decrypted content, it must be at least as long
@@ -350,36 +355,44 @@ func (a *App) ActivateApiKey(w http.ResponseWriter, r *http.Request) {
 
 	err := json.NewDecoder(r.Body).Decode(&requestBody)
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("invalid request: %w", err), http.StatusBadRequest)
+		log.Printf("invalid request in ActivateApiKey: %s", err)
+		jsonResponse(w, invalidRequest, http.StatusBadRequest)
 		return
 	}
 
 	if requestBody.ApiKeyValue == "" {
-		jsonResponse(w, fmt.Errorf("apiKeyValue is required"), http.StatusBadRequest)
+		jsonResponse(w, apiKeyIsRequired, http.StatusBadRequest)
 		return
 	}
 
 	if requestBody.Email == "" {
-		jsonResponse(w, fmt.Errorf("email is required"), http.StatusBadRequest)
+		jsonResponse(w, emailIsRequired, http.StatusBadRequest)
 		return
 	}
 
 	newKey := ApiKey{Key: requestBody.ApiKeyValue, Store: a.db}
 	err = newKey.Load()
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("key not found: %w", err), http.StatusNotFound)
+		if strings.Contains(err.Error(), "does not exist") {
+			jsonResponse(w, apiKeyNotFound, http.StatusNotFound)
+		} else {
+			log.Printf("error loading API Key: %s", err)
+			jsonResponse(w, internalServerError, http.StatusInternalServerError)
+		}
 		return
 	}
 
 	err = newKey.Activate()
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("failed to activate key: %w", err), http.StatusBadRequest)
+		log.Printf("failed to activate key: %s", err)
+		jsonResponse(w, invalidRequest, http.StatusBadRequest)
 		return
 	}
 
 	err = newKey.Save()
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("failed to save key: %w", err), http.StatusInternalServerError)
+		log.Printf("failed to save key: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
@@ -394,25 +407,28 @@ func (a *App) CreateApiKey(w http.ResponseWriter, r *http.Request) {
 
 	err := json.NewDecoder(r.Body).Decode(&requestBody)
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("invalid request: %w", err), http.StatusBadRequest)
+		log.Printf("invalid request in CreateApiKey: %s", err)
+		jsonResponse(w, invalidRequest, http.StatusBadRequest)
 		return
 	}
 
 	if requestBody.Email == "" {
-		jsonResponse(w, fmt.Errorf("email is required"), http.StatusBadRequest)
+		jsonResponse(w, emailIsRequired, http.StatusBadRequest)
 		return
 	}
 
 	key, err := NewApiKey(requestBody.Email)
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("failed to create a random key: %w", err), http.StatusInternalServerError)
+		log.Printf("failed to create a random key: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
 	key.Store = a.db
 	err = key.Save()
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("failed to save key: %w", err), http.StatusInternalServerError)
+		log.Printf("failed to save key: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
@@ -426,33 +442,38 @@ func (a *App) CreateApiKey(w http.ResponseWriter, r *http.Request) {
 func (a *App) RotateApiKey(w http.ResponseWriter, r *http.Request) {
 	requestBody, err := parseRotateKeyRequestBody(r.Body)
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("invalid request: %w", err), http.StatusBadRequest)
+		log.Printf("invalid request in RotateApiKey: %s", err)
+		jsonResponse(w, invalidRequest, http.StatusBadRequest)
 		return
 	}
 
 	oldKey := ApiKey{Key: requestBody[paramOldKeyId], Store: a.GetDB()}
 	err = oldKey.loadAndCheck(requestBody[paramOldKeySecret])
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("old key is not valid: %w", err), http.StatusNotFound)
+		log.Printf("old key is not valid: %s", err)
+		jsonResponse(w, apiKeyNotFound, http.StatusNotFound)
 		return
 	}
 
 	newKey := ApiKey{Key: requestBody[paramNewKeyId], Store: a.GetDB()}
 	err = newKey.loadAndCheck(requestBody[paramNewKeySecret])
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("new key is not valid: %w", err), http.StatusNotFound)
+		log.Printf("new key is not valid: %s", err)
+		jsonResponse(w, apiKeyNotFound, http.StatusNotFound)
 		return
 	}
 
 	totpComplete, totpIncomplete, err := newKey.ReEncryptTOTPs(a.GetDB(), oldKey)
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("failed to re-encrypt TOTP data: %w", err), http.StatusInternalServerError)
+		log.Printf("failed to re-encrypt TOTP data: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
 	webauthnComplete, webauthnIncomplete, err := newKey.ReEncryptWebAuthnUsers(a.GetDB(), oldKey)
 	if err != nil {
-		jsonResponse(w, fmt.Errorf("failed to re-encrypt WebAuthn data: %w", err), http.StatusInternalServerError)
+		log.Printf("failed to re-encrypt WebAuthn data: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 

--- a/apikey.go
+++ b/apikey.go
@@ -23,7 +23,6 @@ const ApiKeyTablePK = "value"
 
 // key rotation request parameters
 const (
-	// TODO: these should be snake case
 	paramNewKeyId     = "newKeyId"
 	paramNewKeySecret = "newKeySecret"
 	paramOldKeyId     = "oldKeyId"

--- a/u2fsimulator/u2fsimulator.go
+++ b/u2fsimulator/u2fsimulator.go
@@ -86,7 +86,7 @@ func jsonResponse(w http.ResponseWriter, body interface{}, status int) {
 	w.WriteHeader(status)
 	_, err = w.Write(jBody)
 	if err != nil {
-		log.Printf("faild to write response in jsonResponse: %s\n", err)
+		log.Printf("faild to write response in jsonResponse: %s", err)
 	}
 }
 

--- a/u2fsimulator/u2fsimulator.go
+++ b/u2fsimulator/u2fsimulator.go
@@ -86,7 +86,7 @@ func jsonResponse(w http.ResponseWriter, body interface{}, status int) {
 	w.WriteHeader(status)
 	_, err = w.Write(jBody)
 	if err != nil {
-		log.Printf("faild to write response in jsonResponse: %s", err)
+		log.Printf("failed to write response in jsonResponse: %s", err)
 	}
 }
 

--- a/u2fsimulator/u2fsimulator.go
+++ b/u2fsimulator/u2fsimulator.go
@@ -123,8 +123,8 @@ func getPrivateKey() *ecdsa.PrivateKey {
 // and also returns the private key
 func GetAuthDataAndPrivateKey(rpID, keyHandle string) (authDataStr string, authData []byte, privateKey *ecdsa.PrivateKey) {
 	// Add in the RP ID Hash (32 bytes)
-	RPIDHash := sha256.Sum256([]byte(rpID))
-	for _, r := range RPIDHash {
+	hash := sha256.Sum256([]byte(rpID))
+	for _, r := range hash {
 		authData = append(authData, r)
 	}
 

--- a/webauthn.go
+++ b/webauthn.go
@@ -49,7 +49,8 @@ type finishLoginResponse struct {
 func (a *App) BeginRegistration(w http.ResponseWriter, r *http.Request) {
 	user, err := getWebauthnUser(r)
 	if err != nil {
-		jsonResponse(w, err, http.StatusBadRequest)
+		log.Printf("failed to get user for BeginRegistration: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
@@ -60,7 +61,8 @@ func (a *App) BeginRegistration(w http.ResponseWriter, r *http.Request) {
 
 	options, err := user.BeginRegistration()
 	if err != nil {
-		jsonResponse(w, fmt.Sprintf("failed to begin registration: %s", err), http.StatusBadRequest)
+		log.Printf("failed to begin registration: %s", err)
+		jsonResponse(w, invalidRequest, http.StatusBadRequest)
 		return
 	}
 
@@ -77,13 +79,15 @@ func (a *App) BeginRegistration(w http.ResponseWriter, r *http.Request) {
 func (a *App) FinishRegistration(w http.ResponseWriter, r *http.Request) {
 	user, err := getWebauthnUser(r)
 	if err != nil {
-		jsonResponse(w, err, http.StatusBadRequest)
+		log.Printf("failed to get user for FinishRegistration: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
 	keyHandleHash, err := user.FinishRegistration(r)
 	if err != nil {
-		jsonResponse(w, err, http.StatusBadRequest)
+		log.Printf("failed to finish registration: %s", err)
+		jsonResponse(w, invalidRequest, http.StatusBadRequest)
 		return
 	}
 
@@ -99,15 +103,15 @@ func (a *App) FinishRegistration(w http.ResponseWriter, r *http.Request) {
 func (a *App) BeginLogin(w http.ResponseWriter, r *http.Request) {
 	user, err := getWebauthnUser(r)
 	if err != nil {
-		jsonResponse(w, err, http.StatusBadRequest)
-		log.Printf("error getting user from context: %s\n", err)
+		log.Printf("failed to get user for BeginLogin: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
 	options, err := user.BeginLogin()
 	if err != nil {
-		jsonResponse(w, err, http.StatusBadRequest)
-		log.Printf("error beginning user login: %s\n", err)
+		log.Printf("error beginning user login: %s", err)
+		jsonResponse(w, invalidRequest, http.StatusBadRequest)
 		return
 	}
 
@@ -119,20 +123,19 @@ func (a *App) BeginLogin(w http.ResponseWriter, r *http.Request) {
 func (a *App) FinishLogin(w http.ResponseWriter, r *http.Request) {
 	user, err := getWebauthnUser(r)
 	if err != nil {
-		jsonResponse(w, err, http.StatusBadRequest)
-		log.Printf("error getting user from context: %s\n", err)
+		log.Printf("failed to get user for FinishLogin: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
 	credential, err := user.FinishLogin(r)
 	if err != nil {
-		jsonResponse(w, err, http.StatusBadRequest)
-
 		// SonarQube flagged this as vulnerable to injection attacks. Rather than exhaustively search for places
 		// where user input is inserted into the error message, I'll just sanitize it as recommended.
 		sanitizedError := strings.ReplaceAll(strings.ReplaceAll(err.Error(), "\n", "_"), "\r", "_")
-		log.Printf("error finishing user login: %s\n", sanitizedError)
+		log.Printf("error finishing user login: %s", sanitizedError)
 
+		jsonResponse(w, invalidRequest, http.StatusBadRequest)
 		return
 	}
 
@@ -149,14 +152,14 @@ func (a *App) FinishLogin(w http.ResponseWriter, r *http.Request) {
 func (a *App) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	user, err := getWebauthnUser(r)
 	if err != nil {
-		jsonResponse(w, err, http.StatusBadRequest)
-		log.Printf("error getting user from context: %s\n", err)
+		log.Printf("failed to get user for DeleteUser: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
 	if err := user.Delete(); err != nil {
-		jsonResponse(w, err, http.StatusInternalServerError)
 		log.Printf("error deleting user: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
@@ -169,25 +172,32 @@ func (a *App) DeleteUser(w http.ResponseWriter, r *http.Request) {
 func (a *App) DeleteCredential(w http.ResponseWriter, r *http.Request) {
 	user, err := getWebauthnUser(r)
 	if err != nil {
-		jsonResponse(w, err, http.StatusBadRequest)
-		log.Printf("error getting user from context: %s\n", err)
+		log.Printf("failed to get user for DeleteCredential: %s", err)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 		return
 	}
 
 	credID := r.PathValue(IDParam)
 	if credID == "" {
 		err := fmt.Errorf("%s path parameter not provided to DeleteCredential, path: %s", IDParam, r.URL.Path)
-		jsonResponse(w, err, http.StatusBadRequest)
-		log.Printf("%s\n", err)
+		log.Printf("%s", err)
+		jsonResponse(w, invalidRequest, http.StatusBadRequest)
 		return
 	}
 
 	status, err := user.DeleteCredential(credID)
 	if err != nil {
-		log.Printf("error deleting user credential: %s", err)
+		log.Printf("error deleting user credential (%d): %s", status, err)
 	}
 
-	jsonResponse(w, err, status)
+	switch status {
+	case http.StatusNoContent:
+		jsonResponse(w, nil, status)
+	case http.StatusNotFound:
+		jsonResponse(w, "Not found", status)
+	case http.StatusInternalServerError:
+		jsonResponse(w, internalServerError, status)
+	}
 }
 
 // fixStringEncoding converts a string from standard Base64 to Base64-URL
@@ -214,7 +224,7 @@ func getWebAuthnFromApiMeta(meta WebauthnMeta) (*webauthn.WebAuthn, error) {
 		Debug:         true,
 	})
 	if err != nil {
-		fmt.Println(err)
+		log.Printf("failed to get new webauthn: %s", err)
 	}
 
 	return web, nil

--- a/webauthn.go
+++ b/webauthn.go
@@ -197,6 +197,9 @@ func (a *App) DeleteCredential(w http.ResponseWriter, r *http.Request) {
 		jsonResponse(w, "Not found", status)
 	case http.StatusInternalServerError:
 		jsonResponse(w, internalServerError, status)
+	default:
+		log.Printf("unexpected status code (%d)", status)
+		jsonResponse(w, internalServerError, http.StatusInternalServerError)
 	}
 }
 

--- a/webauthn_test.go
+++ b/webauthn_test.go
@@ -172,7 +172,7 @@ func (ms *MfaSuite) Test_BeginRegistration() {
 			httpWriter: newLambdaResponseWriter(),
 			httpReq:    http.Request{},
 			wantBodyContains: []string{
-				`"error":"unable to get user from request context"`,
+				`"error":"Internal server error"`,
 			},
 		},
 		{
@@ -311,13 +311,13 @@ func (ms *MfaSuite) Test_FinishRegistration() {
 		{
 			name:             "no user",
 			httpReq:          http.Request{},
-			wantBodyContains: []string{`"error":"unable to get user from request context"`},
+			wantBodyContains: []string{`"error":"Internal server error"`},
 		},
 		{
 			name:    "request has no body",
 			httpReq: reqNoBody,
 			wantBodyContains: []string{
-				`"error":"request Body may not be nil in FinishRegistration"`,
+				`"error":"Invalid request"`,
 			},
 		},
 		{
@@ -479,13 +479,13 @@ func (ms *MfaSuite) Test_BeginLogin() {
 			name:             "no user",
 			httpWriter:       newLambdaResponseWriter(),
 			httpReq:          http.Request{},
-			wantBodyContains: []string{`"error":"unable to get user from request context"`},
+			wantBodyContains: []string{`"error":"Internal server error"`},
 		},
 		{
 			name:             "has a user but no credentials",
 			httpWriter:       newLambdaResponseWriter(),
 			httpReq:          reqNoCredentials,
-			wantBodyContains: []string{`"error":"Found no credentials for user"`},
+			wantBodyContains: []string{`"error":"Invalid request"`},
 		},
 		{
 			name:       "has a user with credentials",
@@ -656,7 +656,7 @@ func (ms *MfaSuite) Test_FinishLogin() {
 		{
 			name:             "no user",
 			httpReq:          http.Request{},
-			wantBodyContains: []string{`"error":"unable to get user from request context"`},
+			wantBodyContains: []string{`"error":"Internal server error"`},
 		},
 		{
 			name:    "with first credential",

--- a/webauthn_test.go
+++ b/webauthn_test.go
@@ -172,7 +172,7 @@ func (ms *MfaSuite) Test_BeginRegistration() {
 			httpWriter: newLambdaResponseWriter(),
 			httpReq:    http.Request{},
 			wantBodyContains: []string{
-				`"error":"Internal server error"`,
+				`"error":"` + internalServerError + `"}`,
 			},
 		},
 		{
@@ -311,13 +311,13 @@ func (ms *MfaSuite) Test_FinishRegistration() {
 		{
 			name:             "no user",
 			httpReq:          http.Request{},
-			wantBodyContains: []string{`"error":"Internal server error"`},
+			wantBodyContains: []string{`"error":"` + internalServerError + `"}`},
 		},
 		{
 			name:    "request has no body",
 			httpReq: reqNoBody,
 			wantBodyContains: []string{
-				`"error":"Invalid request"`,
+				`"error":"` + invalidRequest + `"}`,
 			},
 		},
 		{
@@ -479,13 +479,13 @@ func (ms *MfaSuite) Test_BeginLogin() {
 			name:             "no user",
 			httpWriter:       newLambdaResponseWriter(),
 			httpReq:          http.Request{},
-			wantBodyContains: []string{`"error":"Internal server error"`},
+			wantBodyContains: []string{`"error":"` + internalServerError + `"}`},
 		},
 		{
 			name:             "has a user but no credentials",
 			httpWriter:       newLambdaResponseWriter(),
 			httpReq:          reqNoCredentials,
-			wantBodyContains: []string{`"error":"Invalid request"`},
+			wantBodyContains: []string{`"error":"` + invalidRequest + `"}`},
 		},
 		{
 			name:       "has a user with credentials",
@@ -656,7 +656,7 @@ func (ms *MfaSuite) Test_FinishLogin() {
 		{
 			name:             "no user",
 			httpReq:          http.Request{},
-			wantBodyContains: []string{`"error":"Internal server error"`},
+			wantBodyContains: []string{`"error":"` + internalServerError + `"}`},
 		},
 		{
 			name:    "with first credential",

--- a/webauthnuser.go
+++ b/webauthnuser.go
@@ -77,7 +77,7 @@ func NewWebauthnUser(apiConfig WebauthnMeta, storage *Storage, apiKey ApiKey, we
 
 	err := u.Load()
 	if err != nil {
-		log.Printf("failed to load user: %s\n", err)
+		log.Printf("failed to load user: %s", err)
 	}
 	return u
 }
@@ -107,7 +107,7 @@ func (u *WebauthnUser) saveSessionData(sessionData webauthn.SessionData) error {
 
 	js, err := json.Marshal(sessionData)
 	if err != nil {
-		log.Printf("error marshaling session data to json. Session data: %+v\n Error: %s\n", sessionData, err)
+		log.Printf("error marshaling session data to json. Session data: %+v, Error: %s", sessionData, err)
 		return err
 	}
 
@@ -354,7 +354,7 @@ func (u *WebauthnUser) BeginLogin() (*protocol.CredentialAssertion, error) {
 
 	err = u.saveSessionData(*sessionData)
 	if err != nil {
-		log.Printf("error saving session data: %s\n", err)
+		log.Printf("error saving session data: %s", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
### Security
- Don't send detailed error messages to the client, only send a vague message.

### Fixed
- Don't add a newline when using `log.Printf` since it adds one automatically.
- Correctly wrap errors in `ApiKey#DecryptLegacy`.
- Discern between "not found" and other errors when loading from the database.

### Changed
- Return a json object for errors, not a bare string. Some endpoints already did this, but it should be consistent now.