### PR TITLE
Release 3.0.2 -- Remove credentialId output

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -141,13 +141,19 @@ resource "aws_dynamodb_table" "totp" {
   }
 }
 
+variable "webauthn_stream_view_type" {
+  description = "TEMPORARY: added to resolve an anomaly in the mfa-api_dev_u2f_global table"
+  type        = string
+  default     = "NEW_IMAGE"
+}
+
 resource "aws_dynamodb_table" "webauthn" {
   name                        = "mfa-api_${var.app_env}_u2f_global"
   hash_key                    = "uuid"
   billing_mode                = "PAY_PER_REQUEST"
   deletion_protection_enabled = true
   stream_enabled              = true
-  stream_view_type            = "NEW_IMAGE"
+  stream_view_type            = var.webauthn_stream_view_type
 
   attribute {
     name = "uuid"

--- a/webauthn.go
+++ b/webauthn.go
@@ -40,7 +40,6 @@ type finishRegistrationResponse struct {
 
 // finishLoginResponse contains the response data for the FinishLogin endpoint
 type finishLoginResponse struct {
-	CredentialID  string `json:"credentialId"` // DEPRECATED, use KeyHandleHash instead
 	KeyHandleHash string `json:"key_handle_hash"`
 }
 
@@ -140,7 +139,6 @@ func (a *App) FinishLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := finishLoginResponse{
-		CredentialID:  string(credential.ID),
 		KeyHandleHash: hashAndEncodeKeyHandle(credential.ID),
 	}
 

--- a/webauthn_test.go
+++ b/webauthn_test.go
@@ -662,7 +662,6 @@ func (ms *MfaSuite) Test_FinishLogin() {
 			name:    "with first credential",
 			httpReq: reqWithBody1,
 			wantBodyContains: []string{
-				`"credentialId":"` + credID1 + `"`,
 				`"key_handle_hash":"` + khh1 + `"`,
 			},
 		},
@@ -670,7 +669,6 @@ func (ms *MfaSuite) Test_FinishLogin() {
 			name:    "with second credential",
 			httpReq: reqWithBody2,
 			wantBodyContains: []string{
-				`"credentialId":"` + credID2 + `"`,
 				`"key_handle_hash":"` + khh2 + `"`,
 			},
 		},


### PR DESCRIPTION
### Removed
- Removed `credentialId` output deprecated in v2.6.0

### Fixed
- Created a workaround for a discrepancy in the mfa-api_dev_u2f_global table. The stream view type somehow changed to NEW_AND_OLD_IMAGES and cannot easily be changed back to NEW_IMAGE.